### PR TITLE
Remove HAVE_SIGNAL_H symbol

### DIFF
--- a/php_mysql.c
+++ b/php_mysql.c
@@ -46,9 +46,7 @@
 # include <sys/socket.h>
 # define signal(a, b) NULL
 #else
-# if HAVE_SIGNAL_H
-#  include <signal.h>
-# endif
+# include <signal.h>
 # if HAVE_SYS_TYPES_H
 #  include <sys/types.h>
 # endif


### PR DESCRIPTION
The signal.h header is part of the C89 standard and is present on all today's systems already. The HAVE_SIGNAL_H symbol is defined by PHP's build system and relying on it is neither a good practice neither needed anymore since the signal.h check would always define it.

http://port70.net/~nsz/c/c89/c89-draft.html#4.1.2

Related to removal via https://github.com/php/php-src/pull/4298