### PR TITLE
Remove no_separation flag w/ PHP 8

### DIFF
--- a/php_mysql.c
+++ b/php_mysql.c
@@ -2272,7 +2272,9 @@ static void php_mysql_fetch_hash(INTERNAL_FUNCTION_PARAMETERS, zend_long result_
 			fci.retval = &retval;
 			fci.params = NULL;
 			fci.param_count = 0;
+#if PHP_VERSION_ID < 80000
 			fci.no_separation = 1;
+#endif
 
 			if (ctor_params && Z_TYPE_P(ctor_params) != IS_NULL) {
 				if (zend_fcall_info_args(&fci, ctor_params) == FAILURE) {


### PR DESCRIPTION
This allows the extension to compile. Not sure if something else is required though.